### PR TITLE
Remove duplicate keys causing `npm test` errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,5 @@
 {
   "ecmaFeatures": {
-    "blockBindings": true,
-    "forOf": true,
     "jsx": true,
     "modules": true,
     "classes": true,


### PR DESCRIPTION
`npm test` was failing with duplicate key errors. This fixes that.