### PR TITLE
Adding IP anonymization for GA to at least be something like "dataprotective"

### DIFF
--- a/src/_html/index.html
+++ b/src/_html/index.html
@@ -14,14 +14,5 @@
 <body>
   <div id="tddbin"></div>
   <script src="./index.min.js" type="application/javascript"></script>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-47768219-1', 'tddbin.com');
-      ga('set', 'anonymizeIp', true);
-      ga('send', 'pageview');
-  </script>
 </body>
 </html>

--- a/src/_html/index.html
+++ b/src/_html/index.html
@@ -20,6 +20,7 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
       ga('create', 'UA-47768219-1', 'tddbin.com');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
   </script>
 </body>


### PR DESCRIPTION
If you have to use GA at all, please at least set the anonymizeIP Setting to cut of the last 8 bit of the clients IP.
Better: Remove GA tracking completely and replace it with Piwik or such.