### PR TITLE
Fix path to default kata so new users can get started on tddbin.com

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const withSourceCode = (sourceCode) => {
   setTimeout(onSave, 1000);
 };
 
-const kataName = 'es5/mocha+assert/assert-api';
+const kataName = 'libraries/mocha+assert/assert-api';
 export const DEFAULT_KATA_URL = `http://${process.env.KATAS_SERVICE_DOMAIN}/katas/${kataName}.js`;
 var xhrGetDefaultKata = xhrGet.bind(null, DEFAULT_KATA_URL);
 


### PR DESCRIPTION
tddbin.com is showing a "// Default kata not found (status 404)" error to
first-time users (with empty local storage), most likely because the
file was moved to a different folder in this commit in tddbin/katas:

https://github.com/tddbin/katas/commit/40df1b4ee3e951b9216fcd5915cdc66ffe64bfa1

Note this is an untested change as I'm short on time and it depends on the
server from another repository which I don't know how to run.